### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Response.cpp
+++ b/Response.cpp
@@ -241,7 +241,7 @@ bool Response::SendBody(Socket *aSocket) {
     char* buf = new char[len];
     int x = (int)fread(buf, 1, len, file);
     int r = aSocket->Send(buf, x);
-    delete buf;
+    delete[] buf;
     if (r < 0) {
       // Some kind of error.
       return false;
@@ -277,7 +277,7 @@ bool Response::SendBody(Socket *aSocket) {
     size_t bytesSent = fread(buf, 1, len, file);
     bytesRemaining -= bytesSent;
     int r = aSocket->Send(buf, (int)bytesSent);
-    delete buf;
+    delete[] buf;
     if (r < 0) {
       // Some kind of error.
       return false;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V611 The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] buf;'. response.cpp 244, 280